### PR TITLE
Better error handling, particularly for unicode issues

### DIFF
--- a/oplogreplay/oplogwatcher.py
+++ b/oplogreplay/oplogwatcher.py
@@ -72,8 +72,11 @@ class OplogWatcher(object):
                 logging.warning(e)
                 time.sleep(self.poll_time)
             except OperationFailure, e:
-                logging.exception(e)
+                logging.exception("Error")
                 time.sleep(self.poll_time)
+            except Exception, e:
+                logging.error("Error handling %r" % op)
+                raise
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
`logging.exception` already includes the error object information, so don't need to pass it in.  And passing it in can cause encoding problems.  http://bugs.python.org/issue17155

For others, show what operation failed, and re-raise the exception.
